### PR TITLE
Minor 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Unfortunately, in new Chromium-based Microsoft Edge, the devs decided not to imp
 - Now you can restore one tab from collection without removing
 - Now you can choose if you want to load restored tabs only when you're navigating onto them
 - Set tabs you've selected aside
+- Sync your saved tabs between different PCs
 - **Now available for Firefox!**
 
 ## Download

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Unfortunately, in new Chromium-based Microsoft Edge, the devs decided not to imp
 - Now you can restore one tab from collection without removing
 - Now you can choose if you want to load restored tabs only when you're navigating onto them
 - Set tabs you've selected aside
-- Sync your saved tabs between different PCs
 - **Now available for Firefox!**
 
 ## Download

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Unfortunately, in new Chromium-based Microsoft Edge, the devs decided not to imp
 - Auto Dark mode
 - Now you can restore one tab from collection without removing
 - Now you can choose if you want to load restored tabs only when you're navigating onto them
+- Set tabs you've selected aside
 - **Now available for Firefox!**
 
 ## Download

--- a/TabsAside.html
+++ b/TabsAside.html
@@ -15,6 +15,7 @@
 
 <body>
 	<div class="tabsAside background">
+		<div class="tabsAside closeArea"></div>
 		<aside class="tabsAside pane">
 			<header>
 				<h1 loc="name">Tabs aside</h1>

--- a/css/style.css
+++ b/css/style.css
@@ -10,6 +10,17 @@
 	color: black;
 }
 
+.tabsAside.closeArea
+{
+	position: fixed;
+	top: 0;
+	bottom: 0;
+	right: 0;
+	left: 0;
+
+	background-color: transparent;
+}
+
 .tabsAside.pane
 {
 	user-select: none;

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -74,6 +74,9 @@ function Initialize()
 	document.querySelector(".tabsAside header .btn.remove").addEventListener("click", () =>
 		chrome.runtime.sendMessage({ command: "togglePane" })
 	);
+	document.querySelector(".tabsAside.closeArea").addEventListener("click", () =>
+		chrome.runtime.sendMessage({ command: "togglePane" })
+	);
 
 	document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -211,22 +211,6 @@ function UpdateLocale()
 	);
 }
 
-chrome.storage.onChanged.addListener((changes, namespace) =>
-{
-	if (namespace == "sync")
-		for (key in changes)
-			if (key === "sets")
-				chrome.runtime.sendMessage({ command: "loadData" }, (collections) =>
-				{
-					document.querySelector(".tabsAside section h2").removeAttribute("hidden");
-					document.querySelectorAll(".tabsAside section > div").forEach(i => i.remove());
-
-					if (document.querySelector(".tabsAside.pane section > div") == null)
-						collections.forEach(i =>
-							AddCollection(i));
-				});
-});
-
 function AddCollection(collection)
 {
 	var list = document.querySelector(".tabsAside section");

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -211,6 +211,22 @@ function UpdateLocale()
 	);
 }
 
+chrome.storage.onChanged.addListener((changes, namespace) =>
+{
+	if (namespace == "sync")
+		for (key in changes)
+			if (key === "sets")
+				chrome.runtime.sendMessage({ command: "loadData" }, (collections) =>
+				{
+					document.querySelector(".tabsAside section h2").removeAttribute("hidden");
+					document.querySelectorAll(".tabsAside section > div").forEach(i => i.remove());
+
+					if (document.querySelector(".tabsAside.pane section > div") == null)
+						collections.forEach(i =>
+							AddCollection(i));
+				});
+});
+
 function AddCollection(collection)
 {
 	var list = document.querySelector(".tabsAside section");

--- a/js/background.js
+++ b/js/background.js
@@ -145,13 +145,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>
 			chrome.tabs.create({ url: message.url });
 			break;
 		case "loadData":
-			chrome.storage.sync.get("sets", values =>
-			{
-				if (values?.sets != null)
-					collections = JSON.parse(values?.sets)
-				sendResponse(collections);
-				UpdateTheme();
-			});
+			sendResponse(collections);
 			break;
 		case "saveTabs":
 			SaveCollection();

--- a/js/background.js
+++ b/js/background.js
@@ -1,12 +1,12 @@
 //This variable is populated when the browser action icon is clicked, or a command is called (with a shortcut for example).
 //We can't populate it later, as selected tabs get deselected on a click inside a tab.
-var tabsToSave=[];
+var tabsToSave = [];
 
 
 //Get the tabs to save, either all the window or the selected tabs only, and pass them through a callback.
 function GetTabsToSave(callback)
 {
-		chrome.tabs.query({currentWindow: true}, (windowTabs) =>
+		chrome.tabs.query({ currentWindow: true }, (windowTabs) =>
 		{
 			var highlightedTabs = windowTabs.filter(item => item.highlighted);
 			//If there are more than one selected tab in the window, we set only those aside.
@@ -275,6 +275,10 @@ function RestoreCollection(collectionIndex, removeCollection)
 				});
 			});
 	});
+
+	//We added new tabs by restoring a collection, so we refresh the array of tabs ready to be saved.
+	GetTabsToSave((returnedTabs) => 
+	tabsToSave = returnedTabs)
 
 	if (!removeCollection)
 		return;

--- a/js/background.js
+++ b/js/background.js
@@ -134,6 +134,8 @@ chrome.commands.getAll((commands) => shortcuts = commands);
 chrome.commands.onCommand.addListener(ProcessCommand);
 chrome.contextMenus.onClicked.addListener((info) => ProcessCommand(info.menuItemId));
 
+chrome.runtime.onInstalled.addListener((reason) => chrome.tabs.create({ url: "https://github.com/XFox111/TabsAsideExtension/releases/latest" }));
+
 //We receive a message from the pane aside-script, which means the tabsToSave are already assigned on message reception.
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>
 {

--- a/js/background.js
+++ b/js/background.js
@@ -145,7 +145,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>
 			chrome.tabs.create({ url: message.url });
 			break;
 		case "loadData":
-			sendResponse(collections);
+			chrome.storage.sync.get("sets", values =>
+			{
+				if (values?.sets != null)
+					collections = JSON.parse(values?.sets)
+				sendResponse(collections);
+				UpdateTheme();
+			});
 			break;
 		case "saveTabs":
 			SaveCollection();

--- a/js/background.js
+++ b/js/background.js
@@ -98,22 +98,6 @@ chrome.browserAction.onClicked.addListener((tab) =>
 	});
 });
 
-// Adding context menu options
-chrome.contextMenus.create(
-	{
-		id: "toggle-pane",
-		contexts: ["browser_action"],
-		title: chrome.i18n.getMessage("togglePaneContext")
-	}
-);
-chrome.contextMenus.create(
-	{
-		id: "set-aside",
-		contexts: ["browser_action"],
-		title: chrome.i18n.getMessage("setAside")
-	}
-);
-
 var collections = JSON.parse(localStorage.getItem("sets")) || [];
 var shortcuts;
 chrome.commands.getAll((commands) => shortcuts = commands);
@@ -121,7 +105,25 @@ chrome.commands.getAll((commands) => shortcuts = commands);
 chrome.commands.onCommand.addListener(ProcessCommand);
 chrome.contextMenus.onClicked.addListener((info) => ProcessCommand(info.menuItemId));
 
-chrome.runtime.onInstalled.addListener((reason) => chrome.tabs.create({ url: "https://github.com/XFox111/TabsAsideExtension/releases/latest" }));
+chrome.runtime.onInstalled.addListener((reason) => 
+{
+	chrome.tabs.create({ url: "https://github.com/XFox111/TabsAsideExtension/releases/latest" });
+	// Adding context menu options
+	chrome.contextMenus.create(
+		{
+			id: "toggle-pane",
+			contexts: ["browser_action"],
+			title: chrome.i18n.getMessage("togglePaneContext")
+		}
+	);
+	chrome.contextMenus.create(
+		{
+			id: "set-aside",
+			contexts: ["browser_action"],
+			title: chrome.i18n.getMessage("setAside")
+		}
+	);
+});
 
 //We receive a message from the pane aside-script, which means the tabsToSave are already assigned on message reception.
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>

--- a/js/background.js
+++ b/js/background.js
@@ -114,20 +114,7 @@ chrome.contextMenus.create(
 	}
 );
 
-var collections = [];
-chrome.storage.sync.get("sets", values =>
-{
-	collections = JSON.parse(values?.sets ?? "[]");
-	if (localStorage.getItem("sets"))	// If there're any saved tabs before v1.9 it appends them to a new collection and then removes
-	{
-		console.log("Found legacy data");
-		collections = collections.concat(JSON.parse(localStorage.getItem("sets")))
-		chrome.storage.sync.set({ "sets": JSON.stringify(collections) });
-		localStorage.removeItem("sets");
-	}
-	UpdateTheme();
-});
-
+var collections = JSON.parse(localStorage.getItem("sets")) || [];
 var shortcuts;
 chrome.commands.getAll((commands) => shortcuts = commands);
 
@@ -164,7 +151,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>
 			break;
 		case "renameCollection":
 			collections[message.collectionIndex].name = message.newName;
-			chrome.storage.sync.set({ "sets": JSON.stringify(collections) });
+			localStorage.setItem("sets", JSON.stringify(collections));
 			break;
 		case "togglePane":
 			chrome.tabs.query(
@@ -207,6 +194,7 @@ function UpdateTheme()
 		});
 }
 
+UpdateTheme();
 chrome.windows.onFocusChanged.addListener(UpdateTheme);
 chrome.tabs.onUpdated.addListener(UpdateTheme);
 chrome.tabs.onActivated.addListener(UpdateTheme);
@@ -232,8 +220,18 @@ function SaveCollection()
 		thumbnails: tabs.map(tab => thumbnails.find(i => i.tabId == tab.id)?.url ?? "")
 	};
 
-	collections.unshift(collection);
-	chrome.storage.sync.set({ "sets": JSON.stringify(collections) })
+	var rawData;
+	if (localStorage.getItem("sets") === null)
+		rawData = [collection];
+	else
+	{
+		rawData = JSON.parse(localStorage.getItem("sets"));
+		rawData.unshift(collection);
+	}
+
+	localStorage.setItem("sets", JSON.stringify(rawData));
+
+	collections = JSON.parse(localStorage.getItem("sets"));
 
 	var newTabId;
 	chrome.tabs.create({}, (tab) =>
@@ -248,7 +246,7 @@ function SaveCollection()
 function DeleteCollection(collectionIndex)
 {
 	collections = collections.filter(i => i != collections[collectionIndex]);
-	chrome.storage.sync.set({ "sets": JSON.stringify(collections) })
+	localStorage.setItem("sets", JSON.stringify(collections));
 
 	UpdateTheme();
 }
@@ -281,14 +279,14 @@ function RestoreCollection(collectionIndex, removeCollection)
 	});
 
 	//We added new tabs by restoring a collection, so we refresh the array of tabs ready to be saved.
-	GetTabsToSave((returnedTabs) =>
+	GetTabsToSave((returnedTabs) => 
 	tabsToSave = returnedTabs)
 
 	if (!removeCollection)
 		return;
 
 	collections = collections.filter(i => i != collections[collectionIndex]);
-	chrome.storage.sync.set({ "sets": JSON.stringify(collections) })
+	localStorage.setItem("sets", JSON.stringify(collections));
 
 	UpdateTheme();
 }
@@ -299,7 +297,7 @@ function RemoveTab(collectionIndex, tabIndex)
 	if (--set.tabsCount < 1)
 	{
 		collections = collections.filter(i => i != set);
-		chrome.storage.sync.set({ "sets": JSON.stringify(collections) })
+		localStorage.setItem("sets", JSON.stringify(collections));
 
 		UpdateTheme();
 		return;
@@ -323,7 +321,7 @@ function RemoveTab(collectionIndex, tabIndex)
 	set.links = links;
 	set.icons = icons;
 
-	chrome.storage.sync.set({ "sets": JSON.stringify(collections) })
+	localStorage.setItem("sets", JSON.stringify(collections));
 
 	UpdateTheme();
 }

--- a/js/background.js
+++ b/js/background.js
@@ -1,3 +1,21 @@
+//This variable is populated when the browser action icon is clicked, or a command is called (with a shortcut for example).
+//We can't populate it later, as selected tabs get deselected on a click inside a tab.
+var tabsToSave=[];
+
+
+//Get the tabs to save, either all the window or the selected tabs only, and pass them through a callback.
+function GetTabsToSave(callback)
+{
+		chrome.tabs.query({currentWindow: true}, (windowTabs) =>
+		{
+			var highlightedTabs = windowTabs.filter(item => item.highlighted);
+			//If there are more than one selected tab in the window, we set only those aside.
+			// Otherwise, all the window's tabs get saved.
+			return callback((highlightedTabs.length > 1 ? highlightedTabs : windowTabs));
+		});
+
+}
+
 function TogglePane(tab)
 {
 	if (tab.url.startsWith("http")
@@ -43,31 +61,40 @@ function TogglePane(tab)
 
 function ProcessCommand(command)
 {
-	switch(command)
+	GetTabsToSave((returnedTabs) =>
 	{
-		case "set-aside":
-			SaveCollection();
-			break;
-		case "toggle-pane":
-			chrome.tabs.query(
-				{
-					active: true,
-					currentWindow: true
-				},
-				(tabs) => TogglePane(tabs[0])
-			)
-			break;
-	}
+		tabsToSave = returnedTabs;
+		switch(command)
+		{
+			case "set-aside":
+				SaveCollection();
+				break;
+			case "toggle-pane":
+				chrome.tabs.query(
+					{
+						active: true,
+						currentWindow: true
+					},
+					(tabs) => TogglePane(tabs[0])
+				)
+				break;
+		}
+	});
 }
 
 chrome.browserAction.onClicked.addListener((tab) =>
 {
-	chrome.storage.sync.get({ "setAsideOnClick": false }, values =>
+	GetTabsToSave((returnedTabs) =>
 	{
-		if (values?.setAsideOnClick)
-			SaveCollection();
-		else
-			TogglePane(tab);
+		tabsToSave = returnedTabs;
+
+		chrome.storage.sync.get({ "setAsideOnClick": false }, values =>
+		{
+			if (values?.setAsideOnClick)
+				SaveCollection();
+			else
+				TogglePane(tab);
+		});
 	});
 });
 
@@ -94,6 +121,7 @@ chrome.commands.getAll((commands) => shortcuts = commands);
 chrome.commands.onCommand.addListener(ProcessCommand);
 chrome.contextMenus.onClicked.addListener((info) => ProcessCommand(info.menuItemId));
 
+//We receive a message from the pane aside-script, which means the tabsToSave are already assigned on message reception.
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>
 {
 	switch (message.command)
@@ -172,48 +200,45 @@ chrome.tabs.onActivated.addListener(UpdateTheme);
 // Set current tabs aside
 function SaveCollection()
 {
-	chrome.tabs.query({ currentWindow: true }, (rawTabs) =>
+	var tabs = tabsToSave.filter(i => i.url != chrome.runtime.getURL("TabsAside.html") && !i.pinned && !i.url.includes("//newtab") && !i.url.includes("about:blank") && !i.url.includes("about:home"));
+
+	if (tabs.length < 1)
 	{
-		var tabs = rawTabs.filter(i => i.url != chrome.runtime.getURL("TabsAside.html") && !i.pinned && !i.url.includes("//newtab") && !i.url.includes("about:blank") && !i.url.includes("about:home"));
+		alert(chrome.i18n.getMessage("noTabsToSave"));
+		return;
+	}
 
-		if (tabs.length < 1)
-		{
-			alert(chrome.i18n.getMessage("noTabsToSave"));
-			return;
-		}
+	var collection =
+	{
+		timestamp: Date.now(),
+		tabsCount: tabs.length,
+		titles: tabs.map(tab => tab.title ?? ""),
+		links: tabs.map(tab => tab.url ?? ""),
+		icons: tabs.map(tab => tab.favIconUrl ?? ""),
+		thumbnails: tabs.map(tab => thumbnails.find(i => i.tabId == tab.id)?.url ?? "")
+	};
 
-		var collection =
-		{
-			timestamp: Date.now(),
-			tabsCount: tabs.length,
-			titles: tabs.map(tab => tab.title ?? ""),
-			links: tabs.map(tab => tab.url ?? ""),
-			icons: tabs.map(tab => tab.favIconUrl ?? ""),
-			thumbnails: tabs.map(tab => thumbnails.find(i => i.tabId == tab.id)?.url ?? "")
-		};
+	var rawData;
+	if (localStorage.getItem("sets") === null)
+		rawData = [collection];
+	else
+	{
+		rawData = JSON.parse(localStorage.getItem("sets"));
+		rawData.unshift(collection);
+	}
 
-		var rawData;
-		if (localStorage.getItem("sets") === null)
-			rawData = [collection];
-		else
-		{
-			rawData = JSON.parse(localStorage.getItem("sets"));
-			rawData.unshift(collection);
-		}
+	localStorage.setItem("sets", JSON.stringify(rawData));
 
-		localStorage.setItem("sets", JSON.stringify(rawData));
+	collections = JSON.parse(localStorage.getItem("sets"));
 
-		collections = JSON.parse(localStorage.getItem("sets"));
-
-		var newTabId;
-		chrome.tabs.create({}, (tab) =>
-		{
-			newTabId = tab.id;
-			chrome.tabs.remove(rawTabs.filter(i => !i.pinned && i.id != newTabId).map(tab => tab.id));
-		});
-
-		UpdateTheme();
+	var newTabId;
+	chrome.tabs.create({}, (tab) =>
+	{
+		newTabId = tab.id;
+		chrome.tabs.remove(tabsToSave.filter(i => !i.pinned && i.id != newTabId).map(tab => tab.id));
 	});
+
+	UpdateTheme();
 }
 
 function DeleteCollection(collectionIndex)

--- a/js/background.js
+++ b/js/background.js
@@ -102,14 +102,14 @@ chrome.browserAction.onClicked.addListener((tab) =>
 chrome.contextMenus.create(
 	{
 		id: "toggle-pane",
-		contexts: ['all'],
+		contexts: ["browser_action"],
 		title: chrome.i18n.getMessage("togglePaneContext")
 	}
 );
 chrome.contextMenus.create(
 	{
 		id: "set-aside",
-		contexts: ['all'],
+		contexts: ["browser_action"],
 		title: chrome.i18n.getMessage("setAside")
 	}
 );

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "__MSG_name__",
-	"version": "1.8.1",
+	"version": "1.9",
 	"manifest_version": 2,
 	"description": "__MSG_description__",
 	"author": "__MSG_author__",


### PR DESCRIPTION
Implements following issues: #19, #40, #41

## Changelog
- Now you can close the panel by clicking outside of it (#40)
- Added ability to move only selected tabs aside (#19)
- Context menu entries removed from pages' context menu (#41)
- After update extension now will open GitHub Releases page with the latest version
- Minor performance improvements

## PR Checklist
- [x] Change extension version in the manifest