### PR TITLE
Fixed an issue when restoring tabs then setting them aside

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,12 +1,12 @@
 //This variable is populated when the browser action icon is clicked, or a command is called (with a shortcut for example).
 //We can't populate it later, as selected tabs get deselected on a click inside a tab.
-var tabsToSave=[];
+var tabsToSave = [];
 
 
 //Get the tabs to save, either all the window or the selected tabs only, and pass them through a callback.
 function GetTabsToSave(callback)
 {
-		chrome.tabs.query({currentWindow: true}, (windowTabs) =>
+		chrome.tabs.query({ currentWindow: true }, (windowTabs) =>
 		{
 			var highlightedTabs = windowTabs.filter(item => item.highlighted);
 			//If there are more than one selected tab in the window, we set only those aside.

--- a/js/background.js
+++ b/js/background.js
@@ -276,6 +276,10 @@ function RestoreCollection(collectionIndex, removeCollection)
 			});
 	});
 
+	//We added new tabs by restoring a collection, so we refresh the array of tabs ready to be saved.
+	GetTabsToSave((returnedTabs) => 
+	tabsToSave = returnedTabs)
+
 	if (!removeCollection)
 		return;
 


### PR DESCRIPTION
Fixes this issue from PR #42 (nice number, heh !)
> If you restore tabs, then immediately try to set them aside, it will set aside everything but the restored tabs.

I tested the changes on Chromium, but was able to do so on Firefox as well this time.

I also took care of some code whitespace issues - I tried to follow the contributing guidelines in my previous PR but a few spaces slipped past me