### PR TITLE
Create context menus on extension installation only

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -98,22 +98,6 @@ chrome.browserAction.onClicked.addListener((tab) =>
 	});
 });
 
-// Adding context menu options
-chrome.contextMenus.create(
-	{
-		id: "toggle-pane",
-		contexts: ["browser_action"],
-		title: chrome.i18n.getMessage("togglePaneContext")
-	}
-);
-chrome.contextMenus.create(
-	{
-		id: "set-aside",
-		contexts: ["browser_action"],
-		title: chrome.i18n.getMessage("setAside")
-	}
-);
-
 var collections = JSON.parse(localStorage.getItem("sets")) || [];
 var shortcuts;
 chrome.commands.getAll((commands) => shortcuts = commands);
@@ -121,7 +105,25 @@ chrome.commands.getAll((commands) => shortcuts = commands);
 chrome.commands.onCommand.addListener(ProcessCommand);
 chrome.contextMenus.onClicked.addListener((info) => ProcessCommand(info.menuItemId));
 
-chrome.runtime.onInstalled.addListener((reason) => chrome.tabs.create({ url: "https://github.com/XFox111/TabsAsideExtension/releases/latest" }));
+chrome.runtime.onInstalled.addListener((reason) => 
+{
+	chrome.tabs.create({ url: "https://github.com/XFox111/TabsAsideExtension/releases/latest" });
+	// Adding context menu options
+	chrome.contextMenus.create(
+		{
+			id: "toggle-pane",
+			contexts: ["browser_action"],
+			title: chrome.i18n.getMessage("togglePaneContext")
+		}
+	);
+	chrome.contextMenus.create(
+		{
+			id: "set-aside",
+			contexts: ["browser_action"],
+			title: chrome.i18n.getMessage("setAside")
+		}
+	);
+});
 
 //We receive a message from the pane aside-script, which means the tabsToSave are already assigned on message reception.
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>


### PR DESCRIPTION
A small addition to the 1.9 release : I just noticed the context menus were recreated on all background.js launches, so the extension frequently logs "Unchecked runtime.lastError: Cannot create item with duplicate id toggle-pane". 

It's a meaningless error with no user impact but it still filled the log :) . 

It should no longer happen now, and I tested how disabling/enabling/updating/deleting the extension still results in the context menus being created correctly