### PR TITLE
Option to save a collection to the browser's bookmarks

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -99,6 +99,16 @@
 		"message": "Restore without removing",
 		"description": "Context action item name"
 	},
+	"saveCollectionAsBookmarks":
+	{
+		"message": "Save as bookmarks",
+		"description": "Button allowing the user to save a collection in the browser bookmarks"
+	},
+	"collectionSavedAsBookmarks":
+	{
+		"message": "The collection has been saved in your bookmark bar.",
+		"description": "Alert dialog message when a user has saved a collection in the browser bookmarks"
+	},
 	"removeCollection":
 	{
 		"message": "Remove collection",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -99,6 +99,16 @@
 		"message": "Restaurar sem remover",
 		"description": "Context action item name"
 	},
+	"saveCollectionAsBookmarks":
+	{
+		"message": "Salvar como marcadores",
+		"description": "Button allowing the user to save a collection in the browser bookmarks"
+	},
+	"collectionSavedAsBookmarks":
+	{
+		"message": "A coleção foi salva na sua barra de marcadores.",
+		"description": "Alert dialog message when a user has saved a collection in the browser bookmarks"
+	},
 	"removeCollection":
 	{
 		"message": "Remover coleção",

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -99,6 +99,16 @@
 		"message": "Восстановить без удаления",
 		"description": "Context action item name"
 	},
+	"saveCollectionAsBookmarks":
+	{
+		"message": "Сохранить в избранное",
+		"description": "Button allowing the user to save a collection in the browser bookmarks"
+	},
+	"collectionSavedAsBookmarks":
+	{
+		"message": "Коллекция добавлена в избранное",
+		"description": "Alert dialog message when a user has saved a collection in the browser bookmarks"
+	},
 	"removeCollection":
 	{
 		"message": "Удалить коллекцию",

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -270,6 +270,7 @@ function AddCollection(collection, thumbnails)
 					"<button loc_alt='more' class='btn more' title='More...'>&#xE10C;</button>" +
 					"<nav>" +
 						"<button loc='restoreNoRemove' class='restoreCollection noDelete'>Restore without removing</button>" +
+						"<button loc='saveCollectionAsBookmarks' class='saveCollectionAsBookmarks'>Save as bookmarks</button>" +
 					"</nav>" +
 				"</div>" +
 				"<button loc_alt='removeCollection' class='btn remove' title='Remove collection'>&#xE10A;</button>" +
@@ -289,6 +290,9 @@ function AddCollection(collection, thumbnails)
 
 	list.querySelectorAll(".restoreCollection.noDelete").forEach(i =>
 		i.onclick = () => RestoreTabs(i.parentElement.parentElement.parentElement.parentElement, false));
+
+	list.querySelectorAll(".saveCollectionAsBookmarks").forEach(i =>
+		i.onclick = () => SaveCollectionAsBookmarks(i.parentElement.parentElement.parentElement.parentElement));
 
 	list.querySelectorAll(".set > div").forEach(i =>
 		i.onclick = (args) =>
@@ -323,6 +327,17 @@ function RenameCollection(collectionData, name)
 			newName: name,
 			collectionKey: collectionData.id
 		});
+}
+
+function SaveCollectionAsBookmarks(collectionData)
+{
+	chrome.runtime.sendMessage(
+		{
+			command: "SaveCollectionAsBookmarks",
+			collectionKey: collectionData.id
+		},
+		() => alert(chrome.i18n.getMessage("collectionSavedAsBookmarks"))
+	);
 }
 
 function RestoreTabs(collectionData, removeCollection = true)

--- a/js/background.js
+++ b/js/background.js
@@ -319,6 +319,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) =>
 			collections[message.collectionKey].name = message.newName;
 			UpdateStorages({ [message.collectionKey]: collections[message.collectionKey] });
 			break;
+		case "SaveCollectionAsBookmarks":
+			SaveCollectionAsBookmarks(collections[message.collectionKey]);
+			sendResponse();
+			break;
 		case "togglePane":
 			chrome.tabs.query(
 				{


### PR DESCRIPTION
Implements the project roadmap's card "Add a collection to the bookmarks"

Opening as draft as it can't be merged until #48 is. If #48 is refused I'll just cherry pick what's needed from it and edit it to work with the current storage system

- [x] Adds a user-facing button to add a collection to the bookmarks, using the `SaveCollectionAsBookmarks()` function defined in #48 

- [x] Rebase this branch on major-2.0 once #48 is merged, or rework the PR if #48 is refused.

---
Edit by @XFox111:
TODO: Update translations:
- [x] RU
- [ ] IT
- [x] PT_BR
- [ ] ES
- [ ] ZH_CN