### PR TITLE
Fix the collections pane not reloading if a collection was deleted on another machine

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -247,17 +247,18 @@ chrome.storage.onChanged.addListener((changes, namespace) =>
 				if (changes[key].newValue)
 				{
 					collections[key] = DecompressCollectionsStorage({ [key]: changes[key].newValue })[key];
-					chrome.runtime.sendMessage(
-						{
-							command: "reloadCollections",
-							collections: collections,
-							thumbnails: thumbnails
-						});
+
 				}
 				else
 					delete collections[key];
 
 				UpdateBadgeCounter();
+				chrome.runtime.sendMessage(
+				{
+					command: "reloadCollections",
+					collections: collections,
+					thumbnails: thumbnails
+				});
 			}
 });
 


### PR DESCRIPTION
Quick PR to fix this : 

> The only strange thing I noticed was that deleting a collection in one machine didn't "refresh" an open pane in the other machine (even though the data and the badge updated to the correct numbers, I had to close and reopen the pane to see the collection disappear. This was not needed for other operations (like deleting a tab from a collection). This is not a breaking bug but I'll try to find out why.