### PR TITLE
Setting a single tab aside

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -69,6 +69,11 @@
 		"message": "Set current tabs aside",
 		"description": "Save collection action name. Used in the pane, extension context menu and manifest shortcuts"
 	},
+	"setAsideSelected":
+	{
+		"message": "Set selected tabs aside",
+		"description": "Save collection action name, for selected tabs only. Used in the extension context menu"
+	},
 	"setMultipleTabsAsideTooltip":
 	{
 		"message": "Tip : You can set aside specific tabs by selecting them (by holding CTRL or SHIFT and clicking on the tabs) before clicking on the TabsAside extension",

--- a/js/background.js
+++ b/js/background.js
@@ -297,6 +297,13 @@ chrome.runtime.onInstalled.addListener((updateInfo) =>
 			title: chrome.i18n.getMessage("setAside")
 		}
 	);
+	chrome.contextMenus.create(
+		{
+			id: "set-aside-only-selected",
+			contexts: ["browser_action"],
+			title: chrome.i18n.getMessage("setAsideSelected")
+		}
+	);
 });
 
 //We receive a message from the pane aside-script, which means the tabsToSave are already assigned on message reception.


### PR DESCRIPTION
This PR reopens #68, which implements #63 

I've done the backend code, and tested that it worked through the chrome devtools console for now. I'm not sure how add it to the context menu yet so I'll look into it later. I also believe it would be better to release 2.0 without this PR for now.

PR Checklist
- [x] Backend code for the ability to set a single tab aside
- [x] Add Context Menu item exposing this command 

Localization Checklist :

- [ ] RU
- [ ] IT
- [ ] PT_BR
- [ ] ES
- [ ] ZH_CN