### PR TITLE
Change default 'set tabs aside' shortcut

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "__MSG_name__",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"manifest_version": 2,
 	"description": "__MSG_description__",
 	"author": "__MSG_author__",

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,7 @@
 			"description": "__MSG_setAside__",
 			"suggested_key":
 			{
-				"default": "Alt+Left",
+				"default": "Shift+Alt+Left",
 				"mac": "MacCtrl+T"
 			}
 		},


### PR DESCRIPTION
This shortcut can cause problems for those who are accustomed to using it to go back in history. In Chrome and Edge, it seems to be overridden. Shift+Alt+Left is an unused key combo. 

Implements following issue:
 [Default shortcut overrides browser hotkeys #89](https://github.com/XFox111/TabsAsideExtension/issues/89)

## Changelog
- Changed "Set Tabs Aside" shortcut to `Shift+Alt+Left`